### PR TITLE
quiet; parquets; compression; readability and memory edits

### DIFF
--- a/curve2flood/cli.py
+++ b/curve2flood/cli.py
@@ -32,12 +32,13 @@ def set_log_level(log_level: str):
 def main():
     parser = argparse.ArgumentParser(description="Run Curve2Flood flood mapping tool.")
     parser.add_argument("input_file", help="Path to the input configuration file.")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress all output except errors.")
     parser.add_argument('-l', '--log', type=str, help='Log Level', 
                         default='warn', choices=['debug', 'info', 'warn', 'error'])
     args = parser.parse_args()
 
     set_log_level(args.log)
-    Curve2Flood_MainFunction(args.input_file)
+    Curve2Flood_MainFunction(args.input_file, args.quiet)
 
 if __name__ == "__main__":
     main()

--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -192,7 +192,7 @@ def filter_outliers(group):
     group = group[(group['WSE'] >= lower_bound_wse) & (group['WSE'] <= upper_bound_wse)]
     return group
 
-def Calculate_TW_D_ForEachCOMID(E_DEM, CurveParamFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact):
+def Calculate_TW_D_ForEachCOMID(E_DEM, CurveParamFileName: str, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact):
     num_unique = len(COMID_Unique)
     COMID_Unique_TW = np.zeros(num_unique)
     COMID_Unique_Depth = np.zeros(num_unique)
@@ -200,7 +200,10 @@ def Calculate_TW_D_ForEachCOMID(E_DEM, CurveParamFileName, COMID_Unique_Flow, CO
     LOG.debug('\nOpening and Reading ' + CurveParamFileName)
 
     # read the curve data in as a Pandas dataframe
-    curve_df = pd.read_csv(CurveParamFileName)
+    if CurveParamFileName.endswith('.parquet'):
+        curve_df = pd.read_parquet(CurveParamFileName)
+    else:
+        curve_df = pd.read_csv(CurveParamFileName)
 
     # Reading the COMID and flow data in as Pandas dataframes
     streamflow_df = pd.DataFrame()
@@ -271,11 +274,14 @@ def Find_TopWidth_at_Baseflow_when_using_VDT(QB, flow_values, top_width_values):
         top_width_at_baseflow = top_width_values.min()
     return top_width_at_baseflow
 
-def Calculate_TW_D_ForEachCOMID_VDTDatabase(E_DEM, VDTDatabaseFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact):
+def Calculate_TW_D_ForEachCOMID_VDTDatabase(E_DEM, VDTDatabaseFileName: str, COMID_Unique_Flow, COMID_Unique, T_Rast, W_Rast, TW_MultFact, quiet: bool):
     LOG.debug('\nOpening and Reading ' + VDTDatabaseFileName)
     
     # Read the VDT Database into a DataFrame
-    vdt_df = pd.read_csv(VDTDatabaseFileName)
+    if VDTDatabaseFileName.endswith('.parquet'):
+        vdt_df = pd.read_parquet(VDTDatabaseFileName)
+    else:
+        vdt_df = pd.read_csv(VDTDatabaseFileName)
     
     # Add COMID flow information
     comid_flow_df = pd.DataFrame({'COMID': COMID_Unique, 'Flow': COMID_Unique_Flow})
@@ -322,9 +328,8 @@ def Calculate_TW_D_ForEachCOMID_VDTDatabase(E_DEM, VDTDatabaseFileName, COMID_Un
         # return pd.Series([top_width, depth, wse])
         return[ top_width, depth, wse]
 
-    tqdm.tqdm.pandas(desc="Calculating from VDT", unit="rows")
+    tqdm.tqdm.pandas(desc="Calculating from VDT", unit="rows", disable=quiet)
     # Apply the calculation function to each row
-    # vdt_df = vdt_df.join(vdt_df.apply(calculate_values, axis=1, result_type='expand').rename(columns={0: 'TopWidth', 1: 'Depth', 2: 'WSE'}))
     vdt_df = vdt_df.join(vdt_df.progress_apply(calculate_values, axis=1, result_type='expand').rename(columns={0: 'TopWidth', 1: 'Depth', 2: 'WSE'}))
 
 
@@ -442,7 +447,7 @@ def Write_Output_Raster(s_output_filename, raster_data, ncols, nrows, dem_geotra
     #o_metadata = o_driver.GetMetadata()
     
     # Construct the file with the appropriate data shape
-    o_output_file = o_driver.Create(s_output_filename, xsize=ncols, ysize=nrows, bands=1, eType=s_output_type)
+    o_output_file = o_driver.Create(s_output_filename, xsize=ncols, ysize=nrows, bands=1, eType=s_output_type, options=["COMPRESS=LZW", 'PREDICTOR=2'])
     
     # Set the geotransform
     o_output_file.SetGeoTransform(dem_geotransform)
@@ -542,7 +547,7 @@ def Write_Output_Raster_As_GeoDataFrame(raster_data, ncols, nrows, dem_geotransf
 
 @njit(cache=True)
 def FloodAllLocalAreas(WSE, E_Box, r_min, r_max, c_min, c_max, r_use, c_use):
-    FourMatrix = np.zeros((3,3)) + 4
+    FourMatrix = np.full((3, 3), 4)
     
     nrows_local = r_max-r_min+2
     ncols_local = c_max-c_min+2
@@ -640,9 +645,6 @@ def CreateSimpleFloodMap(RR, CC, T_Rast, W_Rast, E, B, nrows, ncols, sd, TW_m, d
     WSE_Times_Weight = np.zeros((nrows+2,ncols+2), dtype=float)
     Total_Weight = np.zeros((nrows+2,ncols+2), dtype=float)
     
-    WSE_Times_Weight = np.zeros((nrows+2,ncols+2), dtype=float)
-    Total_Weight = np.zeros((nrows+2,ncols+2), dtype=float)
-    
     #Now go through each cell
     num_nonzero = len(RR)
     for i in range(num_nonzero):
@@ -677,10 +679,7 @@ def CreateSimpleFloodMap(RR, CC, T_Rast, W_Rast, E, B, nrows, ncols, sd, TW_m, d
         
         if COMID_TW_m > TW_m:
             COMID_TW_m = TW_m
-        COMID_TW = int(max(round(COMID_TW_m/dx,0),round(COMID_TW_m/dy,0)))  #This is how many cells we will be looking at surrounding our stream cell
-        
-        if COMID_TW<=1:
-            COMID_TW=2
+        COMID_TW = max(round(COMID_TW_m / dx), round(COMID_TW_m / dy))  #This is how many cells we will be looking at surrounding our stream cell
         
         #Find minimum elevation within the search box
         if sd<1:
@@ -695,19 +694,11 @@ def CreateSimpleFloodMap(RR, CC, T_Rast, W_Rast, E, B, nrows, ncols, sd, TW_m, d
                         c_use = cc
         
         
-        r_min = r_use-COMID_TW
-        r_max = r_use+COMID_TW+1
-        if r_min<1:
-            r_min = 1 
-        if r_max>(nrows+1):
-            r_max=nrows+1
-        c_min = c_use-COMID_TW
-        c_max = c_use+COMID_TW+1
-        if c_min<1:
-            c_min = 1 
-        if c_max>(ncols+1):
-            c_max=ncols+1
-        
+        r_min = max(r_use - COMID_TW, 1)
+        r_max = min(r_use + COMID_TW + 1, nrows + 1)
+        c_min = max(c_use - COMID_TW, 1)
+        c_max = min(c_use + COMID_TW + 1, ncols + 1)
+
         #Find what would flood local
         if LocalFloodOption==True:
             E_Box = E[r_min:r_max,c_min:c_max]
@@ -814,18 +805,10 @@ def Create_Topobathy_Dataset(E, nrows, ncols, WeightBox, TW_for_WeightBox_Elipse
             bathy_c = c_cells_to_evaluate[bbb]
             
             for COMID_TW_Bathy in range(1,Max_TW_to_Search_for_Bathy_Point):
-                b_r_min = bathy_r-COMID_TW_Bathy
-                b_r_max = bathy_r+COMID_TW_Bathy+1
-                if b_r_min<1:
-                    b_r_min = 1 
-                if b_r_max>(nrows+1):
-                    b_r_max=nrows+1
-                b_c_min = bathy_c-COMID_TW_Bathy
-                b_c_max = bathy_c+COMID_TW_Bathy+1
-                if b_c_min<1:
-                    b_c_min = 1 
-                if b_c_max>(ncols+1):
-                    b_c_max=ncols+1
+                b_r_min = max(bathy_r - COMID_TW_Bathy, 1)
+                b_r_max = min(bathy_r + COMID_TW_Bathy + 1, nrows + 1)
+                b_c_min = max(bathy_c - COMID_TW_Bathy, 1)
+                b_c_max = min(bathy_c + COMID_TW_Bathy + 1, ncols + 1)
                 
                 # w_r_min = TW_for_WeightBox_ElipseMask-(bathy_r-b_r_min)
                 # w_r_max = TW_for_WeightBox_ElipseMask+b_r_max-bathy_r
@@ -864,18 +847,6 @@ def Create_Topobathy_Dataset(E, nrows, ncols, WeightBox, TW_for_WeightBox_Elipse
 
     Bathy = np.where(Bathy>0, Bathy, E)
 
-    # # Optionally add Perlin noise
-    # if add_noise:
-    #     # Move import here so as not to be a required dependency, since this is false
-    #     import noise
-    #     for i in range(nrows):
-    #         for j in range(ncols):
-    #             noise_value = noise.pnoise2(i * noise_scale, j * noise_scale, 
-    #                                         octaves=noise_octaves, 
-    #                                         persistence=noise_persistence, 
-    #                                         lacunarity=noise_lacunarity)
-    #             Bathy[i, j] += noise_value
-
     return Bathy[1:nrows+1, 1:ncols+1]
 
 def add_noise(Bathy: np.ndarray, noise_scale=0.1, noise_octaves=1, noise_persistence=0.5, noise_lacunarity=2.0):
@@ -889,7 +860,7 @@ def add_noise(Bathy: np.ndarray, noise_scale=0.1, noise_octaves=1, noise_persist
                                         lacunarity=noise_lacunarity)
             Bathy[i, j] += noise_value
 
-def Calculate_Depth_TopWidth_TWMax(E, CurveParamFileName, VDTDatabaseFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact, TopWidthPlausibleLimit, dx, dy, Set_Depth):
+def Calculate_Depth_TopWidth_TWMax(E, CurveParamFileName, VDTDatabaseFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact, TopWidthPlausibleLimit, dx, dy, Set_Depth, quiet):
     if Set_Depth>0.0:
         num_unique = len(COMID_Unique)
         COMID_Unique_TW = np.ones(num_unique, dtype=float) * TopWidthPlausibleLimit
@@ -897,15 +868,16 @@ def Calculate_Depth_TopWidth_TWMax(E, CurveParamFileName, VDTDatabaseFileName, C
         TopWidthMax = TopWidthPlausibleLimit 
     #Mike switched to default to VDT Database instead of Curve.  We can change this in the future.
     elif len(VDTDatabaseFileName)>1:
-        (COMID_Unique_TW, COMID_Unique_Depth, COMID_Unique_WSE, TopWidthMax, T_Rast, W_Rast) = Calculate_TW_D_ForEachCOMID_VDTDatabase(E, VDTDatabaseFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact)
+        (COMID_Unique_TW, COMID_Unique_Depth, COMID_Unique_WSE, TopWidthMax, T_Rast, W_Rast) = Calculate_TW_D_ForEachCOMID_VDTDatabase(E, VDTDatabaseFileName, COMID_Unique_Flow, COMID_Unique, T_Rast, W_Rast, TW_MultFact, quiet)
     elif len(CurveParamFileName)>1:
         (COMID_Unique_TW, COMID_Unique_Depth, TopWidthMax, T_Rast, W_Rast) = Calculate_TW_D_ForEachCOMID(E, CurveParamFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact)
 
     LOG.info('Maximum Top Width = ' + str(TopWidthMax))
     
-    for x in range(len(COMID_Unique)):
-        if COMID_Unique_TW[x]>TopWidthPlausibleLimit:
-            LOG.warning('Ignoring ' + str(COMID_Unique[x]) + '  ' + str(COMID_Unique_Flow[x])  + '  ' + str(COMID_Unique_Flow[x]*Q_Fraction) + '  ' + str(COMID_Unique_Depth[x]) + '  ' + str(COMID_Unique_TW[x]))             
+    if not quiet:
+        for x in range(len(COMID_Unique)):
+            if COMID_Unique_TW[x]>TopWidthPlausibleLimit:
+                LOG.warning('Ignoring ' + str(COMID_Unique[x]) + '  ' + str(COMID_Unique_Flow[x])  + '  ' + str(COMID_Unique_Flow[x]*Q_Fraction) + '  ' + str(COMID_Unique_Depth[x]) + '  ' + str(COMID_Unique_TW[x]))             
     
     if TopWidthPlausibleLimit < TopWidthMax:
         TopWidthMax = TopWidthPlausibleLimit
@@ -917,18 +889,16 @@ def Calculate_Depth_TopWidth_TWMax(E, CurveParamFileName, VDTDatabaseFileName, C
     
     return COMID_Unique_TW, COMID_Unique_Depth, TopWidthMax, TW, T_Rast, W_Rast
 
-def Curve2Flood(E, B, RR, CC, nrows, ncols, dx, dy, COMID_Unique, num_comids, MinCOMID, MaxCOMID, COMID_to_ID, COMID_Unique_Flow, CurveParamFileName, VDTDatabaseFileName, Q_Fraction, TopWidthPlausibleLimit, TW_MultFact, WeightBox, TW_for_WeightBox_ElipseMask, LocalFloodOption, Set_Depth, limit_low_elev_flooding=False, ElevMask=None):
+def Curve2Flood(E, B, RR, CC, nrows, ncols, dx, dy, COMID_Unique, MinCOMID, COMID_to_ID, COMID_Unique_Flow, CurveParamFileName, VDTDatabaseFileName, Q_Fraction, TopWidthPlausibleLimit, TW_MultFact, WeightBox, TW_for_WeightBox_ElipseMask, LocalFloodOption, Set_Depth, quiet, limit_low_elev_flooding=False, ElevMask=None):
     
     #These are gridded data from Curve Parameter or VDT Database File
-    T_Rast = np.zeros((nrows,ncols))
-    W_Rast = np.zeros((nrows,ncols))
-    T_Rast = T_Rast - 1.0
-    W_Rast = W_Rast - 1.0
+    T_Rast = np.full((nrows, ncols), -1.)
+    W_Rast = np.full((nrows, ncols), -1.)
     
     
     #Calculate an Average Top Width and Depth for each stream reach.
     #  The Depths are purposely adjusted to the DEM that you are using (this addresses issues with using the original or bathy dem)
-    (COMID_Unique_TW, COMID_Unique_Depth, TopWidthMax, TW, T_Rast, W_Rast) = Calculate_Depth_TopWidth_TWMax(E, CurveParamFileName, VDTDatabaseFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact, TopWidthPlausibleLimit, dx, dy, Set_Depth)
+    (COMID_Unique_TW, COMID_Unique_Depth, TopWidthMax, TW, T_Rast, W_Rast) = Calculate_Depth_TopWidth_TWMax(E, CurveParamFileName, VDTDatabaseFileName, COMID_Unique_Flow, COMID_Unique, COMID_to_ID, MinCOMID, Q_Fraction, T_Rast, W_Rast, TW_MultFact, TopWidthPlausibleLimit, dx, dy, Set_Depth, quiet)
     #(WeightBox, ElipseMask) = CreateWeightAndElipseMask(TW, dx, dy, TW_MultFact)  #3D Array with the same row/col dimensions as the WeightBox
     
     
@@ -940,9 +910,14 @@ def Curve2Flood(E, B, RR, CC, nrows, ncols, dx, dy, COMID_Unique, num_comids, Mi
     return Flood[1:nrows+1,1:ncols+1]
 
 
-def Set_Stream_Locations(nrows, ncols, infilename):
+def Set_Stream_Locations(nrows: int, ncols: int, infilename: str):
     S = np.zeros((nrows,ncols))  #Create an array
-    df = pd.read_csv(infilename)
+
+    if infilename.endswith('.parquet'):
+        df = pd.read_parquet(infilename)
+    else:
+        df = pd.read_csv(infilename)
+
     S[df['Row'].values, df['Col'].values] = df['COMID'].values
     return S
 
@@ -1028,7 +1003,8 @@ def remove_cells_not_connected(flood_array: np.ndarray, streams_array: np.ndarra
     # Keep only connected chunks in flood_array
     return flood_array * mask
 
-def Curve2Flood_MainFunction(input_file):
+def Curve2Flood_MainFunction(input_file: str, 
+                             quiet: bool = False):
 
     """
     Main function that takes the input file and runs the flood mapping.
@@ -1192,7 +1168,7 @@ def Curve2Flood_MainFunction(input_file):
         #Get an Average Flow rate associated with each stream reach.
         if Set_Depth<=0.000000001:
             FindFlowRateForEachCOMID_Ensemble(comid_file_lines, flow_event_num, COMID_to_ID, MinCOMID, COMID_Unique_Flow)
-        Flood = Curve2Flood(E, B, RR, CC, nrows, ncols, dx, dy, COMID_Unique, num_comids, MinCOMID, MaxCOMID, COMID_to_ID, COMID_Unique_Flow, CurveParamFileName, VDTDatabaseFileName, Q_Fraction, TopWidthPlausibleLimit, TW_MultFact, WeightBox, TW_for_WeightBox_ElipseMask, LocalFloodOption, Set_Depth)
+        Flood = Curve2Flood(E, B, RR, CC, nrows, ncols, dx, dy, COMID_Unique, MinCOMID, COMID_to_ID, COMID_Unique_Flow, CurveParamFileName, VDTDatabaseFileName, Q_Fraction, TopWidthPlausibleLimit, TW_MultFact, WeightBox, TW_for_WeightBox_ElipseMask, LocalFloodOption, Set_Depth, quiet)
         
         Bathy_Yes = False  #This keeps the Bathymetry only running on the first flow rate (no need to run it on all flow rates)
         Flood_Ensemble = Flood_Ensemble + Flood


### PR DESCRIPTION
While making global flood maps, we've made the following edits to improve curve2flood:

- Added the "quiet" flag to toggle progress bar and other common, screen-filling messages
- Ability to read input text files as parquet files based on filename extension
- Compression default on output rasters; comes at almost no extra computation cost and reduces file sizes immensely. 
- A few edits for readability and memory efficiency