### PR TITLE
improving speed, disable VDT cells showing as flooded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .vscode
 *.egg-info
+build/

--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -1335,7 +1335,8 @@ def Curve2Flood_MainFunction(input_file: str,
         except:
             if os.path.exists(BathyWaterMaskFileName):
                 LOG.warning('Could not open ' + BathyWaterMaskFileName)
-            LOG.warning('Going to use the Flood Map ' + Flood_File)
+            if not quiet:
+                LOG.warning('Going to use the Flood Map ' + Flood_File)
             #ARBathyMas = np.where(~np.isnan(Flood_Ensemble), np.where(Flood_Ensemble > 0, 1, 0), 0)
             #ARBathyMask = np.zeros((nrows+2,ncols+2))  #Create an array that is slightly larger than the Bathy Raster Array
             #ARBathyMask[1:(nrows+1), 1:(ncols+1)] = np.where(ARBathyMas>0,1,0)


### PR DESCRIPTION
2 main things here:

- I replicated the interp1d function, and made it 10x faster while still getting the same result
- I added to the Python API the ability to toggle whether row-column pairs from the VDT show show as flooded in the flood map. By default it changes nothing, but toggling it helps visualize what actually is computed as flooded vs what are essentially the stream cell locations. 