### PR TITLE
2x speedup

### DIFF
--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -1419,7 +1419,6 @@ def Curve2Flood_MainFunction(input_file: str = None,
 
     COMID_Unique = np.unique(B[RR, CC]) # Always sorted
     COMID_Unique = COMID_Unique.astype(int) # Ensure it's treated as integers
-    COMID_Unique = np.delete(COMID_Unique, 0)  #We don't need the first entry of zero
 
     # Open the StrmShp_File if provided
     if StrmShp_File:

--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -717,8 +717,6 @@ def create_weightbox(tw: int, dx: float, dy: float):
     # These offsets represent the "cell distance" in each direction.
     X = ((indices - tw) * dx) ** 2 # shape (n,)
     Y = ((indices - tw) * dy) ** 2 # shape (n,)
-    X = X.astype(np.float32)
-    Y = Y.astype(np.float32)
     
     # Broadcast to compute the squared distances:
     # For every cell, z2 = (dx * (x offset))^2 + (dy * (y offset))^2.
@@ -1408,8 +1406,8 @@ def Curve2Flood_MainFunction(input_file: str = None,
         num_flows = 1
 
     # Create initial rasters once, outside the loop
-    T_Rast = np.empty((nrows,ncols), np.float32)
-    W_Rast = np.empty((nrows,ncols), np.float32)
+    T_Rast = np.empty((nrows,ncols), np.float64)
+    W_Rast = np.empty((nrows,ncols), np.float64)
 
     #Go through all the Flow Events
     Flood_array_list = []

--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -375,10 +375,10 @@ def Calculate_TW_D_ForEachCOMID_VDTDatabase(E_DEM, VDTDatabaseFileName: str, COM
     e_dem = E_DEM[vdt_df['Row'].values + 1, vdt_df['Col'].values + 1]
 
     # Extract flow, TopWidth, and WSE values for interpolation
-    flow_values = vdt_df.iloc[:, flow_cols].values
-    top_width_values = vdt_df.iloc[:, top_width_cols].values
-    wse_values = vdt_df.iloc[:, wse_cols].values
-    elev_values = vdt_df['Elev'].values
+    flow_values = vdt_df.iloc[:, flow_cols].values.astype(np.float64)
+    top_width_values = vdt_df.iloc[:, top_width_cols].values.astype(np.float64)
+    wse_values = vdt_df.iloc[:, wse_cols].values.astype(np.float64)
+    elev_values = vdt_df['Elev'].values.astype(np.float64)
 
     top_width, depth, wse = vdt_interpolate(flow, qb, flow_values, top_width_values, elev_values, wse_values, e_dem, TW_MultFact)
 
@@ -400,6 +400,7 @@ def Calculate_TW_D_ForEachCOMID_VDTDatabase(E_DEM, VDTDatabaseFileName: str, COM
 
     # Drop rows with NaN values introduced during outlier removal
     vdt_df = vdt_df.dropna(subset=['TopWidth', 'Depth', 'WSE'])
+    vdt_df.to_csv('vdt_filtered.csv', index=False)
     
     # Fill T_Rast and W_Rast
     T_Rast[vdt_df['Row'], vdt_df['Col']] = vdt_df['TopWidth']

--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -895,7 +895,7 @@ def CreateSimpleFloodMap(RR, CC, T_Rast, W_Rast, E, B, nrows, ncols, sd, TW_m, d
 
     return Flooded_array[1:-1, 1:-1], Depth_array[1:-1, 1:-1], WSE_array[1:-1, 1:-1]
 
-@njit(cache=True)
+@njit("float32[:](float64)", cache=True)
 def create_gaussian_kernel_1d(sigma):
     kernel_size = int(6 * sigma + 1)
     if kernel_size % 2 == 0:
@@ -913,7 +913,7 @@ def create_gaussian_kernel_1d(sigma):
 
     return kernel
 
-@njit(cache=True)
+@njit("float64[:, :](float64[:, :], float32[:])", cache=True)
 def convolve_rows(image: np.ndarray, kernel: np.ndarray) -> np.ndarray:
     nrows, ncols = image.shape
     klen = len(kernel)
@@ -938,7 +938,7 @@ def convolve_rows(image: np.ndarray, kernel: np.ndarray) -> np.ndarray:
             output[r, c] = acc / weight_sum if weight_sum > 0 else image[r, c]
     return output
 
-@njit(cache=True)
+@njit("float64[:, :](float64[:, :], float32[:])", cache=True)
 def convolve_cols(image, kernel):
     nrows, ncols = image.shape
     klen = len(kernel)
@@ -962,7 +962,7 @@ def convolve_cols(image, kernel):
             output[r, c] = acc / weight_sum if weight_sum > 0 else image[r, c]
     return output
 
-@njit(cache=True)
+@njit("float64[:, :](float64[:, :], float64)", cache=True)
 def gaussian_blur_separable(image, sigma):
     kernel = create_gaussian_kernel_1d(sigma)
     blurred = convolve_rows(image, kernel)


### PR DESCRIPTION
In the quest to generate global floodmaps, we've worked on making this go faster. Was able to get average timings from 2.1 sec to 0.8 sec for a 30 meter 1x1 degree DEM tile without bathmetry, 4.3 sec to 2.3 sec with bathymetry.

Changes:

- Numba signatures on some functions help load in much quicker
- pyarrow dependency to speed up CSV/parquet reading
- Improved weightbox creation speed
- Several edits for readability + memory consumption improve performance (such as using np.uint8 instead of np.float arrays)

I have tests to verify that both the burned DEM and the floodmaps generated with this pull request are identical.