### PR TITLE
use pandas to open files, compile bathymetry, fix types, speedups!

### DIFF
--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -358,7 +358,7 @@ def Calculate_TW_D_V_ForEachCOMID_CurveFile(CurveParamFileName: str, COMID_Uniqu
 
     # TO DO!!!  This needs to be redone to focus the bounds based on the COMID. This is taking out too many values (I think)
     # Apply the outlier filtering function to each COMID group
-    curve_df = curve_df.groupby('COMID', group_keys=False).apply(filter_outliers, include_groups=True)
+    curve_df = curve_df.groupby('COMID', group_keys=False).apply(filter_outliers, include_groups=False)
 
     # Fill in the T_Rast and W_Rast
     for index, row in curve_df.iterrows():
@@ -572,7 +572,7 @@ def Calculate_TW_D_V_ForEachCOMID_VDTDatabase(E_DEM, VDTDatabaseFileName: str, C
 
     # TO DO!!!  This needs to be redone to focus the bounds based on the COMID. This is taking out too many values (I think)
     # Apply the outlier filtering function to each COMID group
-    vdt_df = vdt_df.groupby('COMID', group_keys=False).apply(filter_outliers, include_groups=True)
+    vdt_df: pd.DataFrame = vdt_df.groupby('COMID', group_keys=False).apply(lambda df: filter_outliers(df).assign(COMID=df.name), include_groups=False)
     
     # Fill T_Rast, W_Rast, and S_Rast
     T_Rast[vdt_df['Row'], vdt_df['Col']] = vdt_df['TopWidth']

--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -358,7 +358,7 @@ def Calculate_TW_D_V_ForEachCOMID_CurveFile(CurveParamFileName: str, COMID_Uniqu
 
     # TO DO!!!  This needs to be redone to focus the bounds based on the COMID. This is taking out too many values (I think)
     # Apply the outlier filtering function to each COMID group
-    curve_df = curve_df.groupby('COMID', group_keys=False).apply(filter_outliers)
+    curve_df = curve_df.groupby('COMID', group_keys=False).apply(filter_outliers, include_groups=True)
 
     # Fill in the T_Rast and W_Rast
     for index, row in curve_df.iterrows():
@@ -572,7 +572,7 @@ def Calculate_TW_D_V_ForEachCOMID_VDTDatabase(E_DEM, VDTDatabaseFileName: str, C
 
     # TO DO!!!  This needs to be redone to focus the bounds based on the COMID. This is taking out too many values (I think)
     # Apply the outlier filtering function to each COMID group
-    vdt_df = vdt_df.groupby('COMID', group_keys=False).apply(filter_outliers)
+    vdt_df = vdt_df.groupby('COMID', group_keys=False).apply(filter_outliers, include_groups=True)
     
     # Fill T_Rast, W_Rast, and S_Rast
     T_Rast[vdt_df['Row'], vdt_df['Col']] = vdt_df['TopWidth']


### PR DESCRIPTION
By using pandas to open the flow file, the flow file can exist on s3.
Njit on bathymetry creation function.
Fixed type annotation.

Added two new options to python API: fast_vdt, and parallel.
Using fast_vdt, we use an outlier removal method that is faster, but due to floating point differences between pandas, numpy, and numba, produces slightly different results (0.025% of flooded cells changed). 
Using parallel, we can speed up the main simple floodmap loop substantially, at the cost of very minor differences (0.0003% of flooded cells changed)
The user may want to use these functions to gain the speedups, especially at large scales