### PR TITLE
2x+ faster bathymetry calculation

### DIFF
--- a/curve2flood/core.py
+++ b/curve2flood/core.py
@@ -793,7 +793,7 @@ def Write_Output_Raster_As_GeoDataFrame(raster_data, ncols, nrows, dem_geotransf
     mask_band = raster_ds.GetRasterBand(1).GetMaskBand()
 
     # Create an in-memory vector layer for the polygonized data
-    memory_driver = ogr.GetDriverByName('Memory')
+    memory_driver = (ogr.GetDriverByName('MEM') or ogr.GetDriverByName('Memory'))
     vector_ds = memory_driver.CreateDataSource('')
     srs = osr.SpatialReference()
     srs.ImportFromWkt(dem_projection)


### PR DESCRIPTION
I found that, the default method of doing the weight is not optimal for parallelization. The current approach is, we visit each stream cell, find the area around it, compute weight and wse, then add to total WSE and weight arrays. A different approach is to visit each row and column, compute all of the weight and wse influences on that cell alone, and assign that weight and wse to the total WSE and weight arrays, just for that row and column. This is much more parallelizable, and indeed, for a 1x1 30 m tile, reduces total curve2flood time from 10 sec to 4 sec. 

This approach could be implemented in the main weighted method in the simple flood map, but that is likely easier done by Joseph or Mike who know that section better.